### PR TITLE
Fix organization name

### DIFF
--- a/.github/workflows/eks-node-drain-based-on-karpenter-allocate-rate.yaml
+++ b/.github/workflows/eks-node-drain-based-on-karpenter-allocate-rate.yaml
@@ -31,11 +31,11 @@ on:
         description: '프로메테우스 미미르 프록시 org-id 입니다.'
         type: choice
         options:
-          - 'orgainization-dev'
-          - 'orgainization-alp'
-          - 'orgainization-prd'
+          - 'organization-dev'
+          - 'organization-alp'
+          - 'organization-prd'
         required: true
-        default: 'orgainization-dev'
+        default: 'organization-dev'
       NODEPOOL_NAME:
         description: '드레인 하려는 Nodepool 이름입니다.'
         type: choice

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ node drain
 ```sh
 go run main.go drain \
   --prometheus-address "http://localhost:8080/prometheus" \
-  --prometheus-org-id "orgainization-dev" \
+  --prometheus-org-id "organization-dev" \
   --nodepool-name "worker-nodepool-name" \
   --slack-webhook-url "https://hooks.slack.com/services/XXXXXXXX" \
   --kube-config "local" \
@@ -29,7 +29,7 @@ karpenter allocate rate
 ```sh
 go run main.go karpenter allocate-rate \
   --prometheus-address "http://localhost:8080/prometheus" \
-  --prometheus-org-id "orgainization-dev" \
+  --prometheus-org-id "organization-dev" \
   --nodepool-name "worker-nodepool-name" \
   --kube-config "local" \
   --cluster-name "devel_eks_cluster"


### PR DESCRIPTION
## Summary
- fix orgainization -> organization in README examples
- correct default value for PROMETHEUS_ORG_ID in GitHub workflow

## Testing
- `gofmt -w cmd/root.go`
- `find . -name '*.go' -not -path './vendor/*' | xargs gofmt -w`
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_684bcf077cbc83278ae8225d0396b5c4