### PR TITLE
Fix drainNodeCount edge cases

### DIFF
--- a/pkg/node/node_drain.go
+++ b/pkg/node/node_drain.go
@@ -94,9 +94,18 @@ func getDrainNodeCount(clientSet kubernetes.Interface, lenNodes int) (int, error
 	slog.Info("최대 사용률", "maxAllocateRate", maxAllocateRate)
 
 	drainRate := float64(99-maxAllocateRate) / 100.0
+	if drainRate < 0 {
+		drainRate = 0
+	}
 	slog.Info("드레인 비율", "drainRate", drainRate)
 
 	drainNodeCount := int(float64(lenNodes) * drainRate)
+	if drainNodeCount < 0 {
+		drainNodeCount = 0
+	}
+	if drainNodeCount > lenNodes {
+		drainNodeCount = lenNodes
+	}
 
 	return drainNodeCount, nil
 }


### PR DESCRIPTION
## Summary
- guard against negative drainRate in node draining logic

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_6847ef9bcd8c8327a87d0c3782765d60